### PR TITLE
Pass host header to horizon

### DIFF
--- a/deploy/ansible/playbooks/roles/horizon-nginx-proxy/files/docker-compose.yml
+++ b/deploy/ansible/playbooks/roles/horizon-nginx-proxy/files/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3"
 
 services:
   horizon-nginx-proxy:
-    image: kinecosystem/horizon-nginx-proxy:705f69d
+    image: kinecosystem/horizon-nginx-proxy:34300
     container_name: horizon-nginx-proxy
 
     network_mode: host
@@ -13,6 +13,9 @@ services:
       PROXY_READ_TIMEOUT: 60
       # horizon listens on port 8000
       PROXY_PASS_URL: http://localhost:8000
+      # Set host for Horizon's response links, leave as $$host for the links to show the original request host(localhost)
+      HOST: $$host
+
 
     restart: on-failure
     logging:

--- a/deploy/horizon-nginx-proxy/Dockerfile
+++ b/deploy/horizon-nginx-proxy/Dockerfile
@@ -2,4 +2,4 @@ FROM nginx:1.15.1-alpine
 
 COPY ./nginx.conf.tmpl /etc/nginx/
 EXPOSE 80 443
-CMD envsubst '$PROXY_LISTEN_PORT $PROXY_READ_TIMEOUT $PROXY_PASS_URL' < /etc/nginx/nginx.conf.tmpl > /etc/nginx/nginx.conf && exec nginx
+CMD envsubst '$HOST $PROXY_LISTEN_PORT $PROXY_READ_TIMEOUT $PROXY_PASS_URL' < /etc/nginx/nginx.conf.tmpl > /etc/nginx/nginx.conf && exec nginx

--- a/deploy/horizon-nginx-proxy/nginx.conf.tmpl
+++ b/deploy/horizon-nginx-proxy/nginx.conf.tmpl
@@ -28,6 +28,7 @@ http {
       # http://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive
       proxy_http_version 1.1;
       proxy_set_header Connection "";
+      proxy_set_header Host   ${HOST};
       proxy_pass ${PROXY_PASS_URL};
 
       # if the request is for sse, return 200 instead of 504

--- a/image/docker-compose.yml
+++ b/image/docker-compose.yml
@@ -51,8 +51,8 @@ services:
   horizon:
     image: kinecosystem/horizon
     # using nginx-proxy
-    # ports:
-    #   - 8000:8000
+    ports:
+      - 8000:8000
     links:
       - horizon-db
       - stellar-core-1
@@ -95,15 +95,17 @@ services:
       POSTGRES_DB: horizon
 
   horizon-nginx-proxy:
-    image: kinecosystem/horizon-nginx-proxy:latest
+    image: kinecosystem/horizon-nginx-proxy:34300
     ports:
-      - 8000:80
+      - 8008:80
     links:
       - horizon
     environment:
       PROXY_LISTEN_PORT: 80
       PROXY_READ_TIMEOUT: 10
       PROXY_PASS_URL: http://horizon:8000
+      # Set host for Horizon's response links, leave as $$host for the links to show the original request host
+      HOST: $$host
 
   # friendbot was originally part of horizon
   # but extracted to its own microservice since horizon v0.12.2


### PR DESCRIPTION
Fix #34 

Pass the Host header to Horizon to change the links that are being sent back.

If we dont do this, the links show "localhost:8000" since this is where nginx sends the request
If we use this update, and leave HOST as $$host, the links should be "ec2-****"

So I think the best way will be to edit HOST to be the url of the load balancer.
```
HOST: horizon-playground.kininfrastructure.com
```